### PR TITLE
Fixes and Better Item Popping

### DIFF
--- a/Modules/Core/Core.cs
+++ b/Modules/Core/Core.cs
@@ -7,6 +7,7 @@ exec("./Support_FloatingBricks.cs");
 exec("./Support_ArbyVars.cs");
 exec("./Support_Saving.cs");
 exec("./Support_TransferNewFiles.cs");
+exec("./Support_NewPop.cs");
 exec("./BotDebug.cs");
 
 $GameModeDisplayName = "SA EX2";

--- a/Modules/Core/Extra.cs
+++ b/Modules/Core/Extra.cs
@@ -36,7 +36,7 @@ function doTipLoop(%num)
 		case 12: %text = "\c5Tip\c6: Your hammer can deal minor damage to enemies. This ability cannot be spamfired, unfortunately.";
 		case 13: %text = "\c5Tip\c6: The \"/Help\" command will tell you what special commands exist.";
 		case 14: %text = "\c5Tip\c6: Complex logistics can be done with the use of VCE.";
-		case 15: %text = "\c5Tip\c6: Upgrading a machine will enable it to process lower tier recipes in parallel.";/
+		case 15: %text = "\c5Tip\c6: Upgrading a machine will enable it to process lower tier recipes in parallel.";
 		case 16: %text = "\c5Tip\c6: While mininum or higher shaders might look pretty, having shaders OFF will provide the best visual clarity, especially at night.";
 		default: %text = "\c5Tip\c6: Dying is bad, don't do it. You will drop all held tools on death. Held materials (ie Iron) will be kept."; %num = 0;
 	}

--- a/Modules/Core/Support_NewPop.cs
+++ b/Modules/Core/Support_NewPop.cs
@@ -1,0 +1,76 @@
+//schedule pop rewrite so it isn't so schedule stupid
+//this should only ever use 1 schedule :) so nice
+if(!isObject($ItemPopSet))
+{
+	$ItemPopSet = new SimSet();
+}
+
+function Item::schedulePop(%obj)
+{
+	%obj.popTime = getSimTime() + $Game::Item::PopTime - 1000;
+	$ItemPopSet.add(%obj);
+	%obj.startFade(0,0,1);
+
+	if($ItemPopSet.isLooping)
+	{
+		return;
+	}
+
+	//makes sure no quota objects delete the schedule
+	%oldQuotaObject = getCurrentQuotaObject();
+	if (isObject(%oldQuotaObject))
+	{
+		clearCurrentQuotaObject();
+	}
+	$ItemPopSet.isLooping = true;
+	PopSet_Loop();
+	if (isObject(%oldQuotaObject))
+	{
+		setCurrentQuotaObject(%oldQuotaObject);
+	}
+}
+
+function Item::cancelPop(%obj)
+{
+	if(!$ItemPopSet.isMember(%obj))
+	{
+		return;
+	}
+
+	%obj.setNodColor("ALL","0 0 0 1");
+	%obj.startFade(0,0,0);
+	$ItemPopSet.remove(%obj);
+}
+
+function PopSet_Loop()
+{
+	%set = $ItemPopSet;
+	%count = %set.getCount();
+
+	if(%count == 0)
+	{
+		%set.isLooping = false;
+		return;
+	}
+	
+	%time = getSimTime();
+	for(%i = 0; %i < %count; %i++)
+	{
+		%item = %set.getObject(%i);
+		
+		if((%item.popTime - %time) > 0)
+		{
+			continue;
+		}
+		
+		%opacity = 1 + (%item.popTime - %time) / 1000;
+		if(%opacity <= 0)
+		{
+			%item.schedule(0,"delete");
+			continue;
+		}
+		
+		%item.setNodeColor("ALL","0 0 0" SPC %opacity);
+	}
+	$ItemPopSet.scheduleloop = schedule(100,%set,"PopSet_Loop");
+}

--- a/Modules/Environment/Event_OnSun.cs
+++ b/Modules/Environment/Event_OnSun.cs
@@ -21,6 +21,7 @@ function fxDTSBrick::onSunSet(%obj, %client)
 
 function runSunCheckEvents(%sunRise)
 {
+    %obj = $DefaultMinigame;
     %i = 0;
     while (%i < %obj.numMembers)
     {

--- a/Modules/Matter/Item_MaterialPickup.cs
+++ b/Modules/Matter/Item_MaterialPickup.cs
@@ -68,7 +68,6 @@ function EOTW_SpawnOreDrop(%amt, %type, %loc)
 	};
 	
 	%item.setVelocity(getRandom(-7,7) SPC getRandom(-7,7) SPC 7);
-	%item.schedulePop();
 	
 	return %item;
 }

--- a/Modules/Matter/Support_Pipes.cs
+++ b/Modules/Matter/Support_Pipes.cs
@@ -107,6 +107,8 @@ datablock fxDTSBrickData(brickEOTWMatterPipeExtractor3Data : brickEOTWMatterPipe
 $EOTW::CustomBrickCost["brickEOTWMatterPipeExtractor3Data"] = 1.00 TAB "" TAB 128 TAB "Naturum" TAB 16 TAB "Piping";
 $EOTW::BrickDescription["brickEOTWMatterPipeExtractor3Data"] = "Superior Matter Extractor. (32 Units/tick)";
 
+function brickEOTWMatterPipeExtractor3Data::onTick(%this, %obj) { %obj.runPipingTick(); }
+
 datablock fxDTSBrickData(brickEOTWMatterSteamExtractorData : brickEOTWMatterPipeExtractor1Data)
 {
 	uiName = "Steam Extractor";


### PR DESCRIPTION
I saw a couple of broken things and a typo that broke the gamemode. The new item popping is in response to the 7 schedules per item that the game usually uses. This should eliminate all schedules spawned by items on the ground and replace it with a single schedule that runs when needed.