### PR TITLE
Plants

### DIFF
--- a/Modules/Core/CreateBrick.cs
+++ b/Modules/Core/CreateBrick.cs
@@ -56,12 +56,13 @@ function CreateBrick(%cl, %data, %pos, %color, %angleID, %checkSpace)
 		shapeFxID = 0;
 		stackBL_ID = %blid;
 	}).angleID = %angleID;
-	%err = %brick.plant();
-	%brick.setTrusted(1);
-	if(%flag && isObject(%cl.brickgroup))
+	if(%flag && isObject(%cl.brickgroup))//brick group should be added before planted
 		%cl.brickgroup.add(%brick);
 	else if(isObject(%group))
 		%group.add(%brick);
+	%err = %brick.plant();
+	%brick.setTrusted(1);
+
 	return %brick TAB %err;
 }
 

--- a/Modules/Matter/Support_Plants.cs
+++ b/Modules/Matter/Support_Plants.cs
@@ -3,8 +3,7 @@
 //plants that have determined they can't grow will be removed from the plant set to prevent the likelyhood of dead plant ticks
 //this solution saves and is easily stopped from being modified by players
 
-$EOTW::PlantGrowthChance = 1
-;
+$EOTW::PlantGrowthChance = 1/15;
 function PlantLife_TickLoop()
 {
     cancel($EOTW::PlantLifeLoop);

--- a/Modules/Matter/Support_Plants.cs
+++ b/Modules/Matter/Support_Plants.cs
@@ -3,7 +3,7 @@
 //plants that have determined they can't grow will be removed from the plant set to prevent the likelyhood of dead plant ticks
 //this solution saves and is easily stopped from being modified by players
 
-$EOTW::PlantGrowthChance = 1/30;
+$EOTW::PlantGrowthChance = 1/100;
 $EOTW::MaxPlantTicks = 50;
 function PlantLife_TickLoop()
 {

--- a/Modules/Matter/Support_Plants.cs
+++ b/Modules/Matter/Support_Plants.cs
@@ -1,145 +1,175 @@
+//goal is to remake plant life and make them more interesting
+//the plant uses paint colors to decide what that part of the plant can do
+//plants that have determined they can't grow will be removed from the plant set to prevent the likelyhood of dead plant ticks
+//this solution saves and is easily stopped from being modified by players
+
+$EOTW::PlantGrowthChance = 1
+;
 function PlantLife_TickLoop()
 {
     cancel($EOTW::PlantLifeLoop);
-    if (isObject(EOTWPlants) && EOTWPlants.getCount() >= 1)
+
+    %clientGroup = ClientGroup;
+    %count = %clientGroup.getCount();
+
+    %totalPlants = 0;
+    for(%i = 0; %i < %count; %i++)
     {
-        %totalTicks = 0;
-        for (%i = mLog(EOTWPlants.getCount() / 100); %i > 0; %i--)
-            if (getRandom() < %i)
-                %totalTicks++;
-
-        for (%i = 0; %i < %totalTicks; %i++)
+        %brickGroup = %clientGroup.getObject(%i).brickgroup;
+        if(!isObject(%brickGroup.EOTWPlants) || %brickGroup.EOTWPlants.getCount() == 0)
         {
-            %plant = EOTWPlants.getObject(getRandom(0, EOTWPlants.getCount() - 1));
-
-            if (%groupTicked[%plant.getGroup().bl_id] < 5)
-            {
-                %groupTicked[%plant.getGroup().bl_id]++;
-                %plant.EOTW_PlantLifeTick();
-            }
+            continue;
         }
-            
+
+        %totalPlants += %brickGroup.EOTWPlants.getCount();
+        %hasPlants = %hasPlants SPC %brickGroup; 
     }
+
+    %hasPlants = lTrim(%hasPlants);
+    %hasPlantsCount = getWordCount(%hasPlants);
+
+    if(%hasPlantsCount != 0)
+    {
+        %plantTicks = %totalPlants * $EOTW::PlantGrowthChance;
+        %plantTicks = mFloor(%plantTicks) + (%plantTicks > (mFloor(%plantTicks) + getRandom()));
+        
+        for(%i = 0; %i < %plantTicks; %i++)
+        {
+            %plantGroup = getWord(%hasPlants,getRandom(0,%hasPlantsCount - 1)).EOTWPlants;
+            %plant = %plantGroup.getObject(getRandom(0, %plantGroup.getCount() - 1));
+            %plant.getDatablock().grow(%plant);
+        }
+    }
+    
     $EOTW::PlantLifeLoop = schedule(1000, 0, "PlantLife_TickLoop");
 }
 $EOTW::PlantLifeLoop = schedule(1000, 0, "PlantLife_TickLoop");
 
-function fxDtsBrick::EOTW_PlantLifeTick(%obj)
+// function fxDtsBrick::EOTW_PlantLifeTick(%obj)
+// {
+//     //Vines will attempt to grow along walls
+//     //Moss will attempt to grow along floors and ceilings. Will not stack vertically.
+//     //Cacti will grow only grow upwards, up to a stack limit. Will not grow if horizontally adjacent to another cacti block
+//     //All types will only grow on blocks owned by the same bl_id
+//     //bl_id 888888 and 1337 are blacklisted completely
+//     if (!isObject(%client = %obj.getGroup().client))
+//         return;
+
+//     %data = %obj.getDatablock();
+
+//     if (%data.getName() $= "brickEOTWVinesData")
+//     {
+       
+//     }
+//     else if (%data.getName() $= "brickEOTWMossData")
+//     {
+
+//     }
+//     else if (%data.getName() $= "brickEOTWCactiData")
+//     {
+
+        
+//     }
+//     else if (%data.getName() $= "brickEOTWDeadPlantData")
+//     {
+//         %obj.energy--;
+//         if (%obj.energy < -10)
+//         {
+//             %obj.dontRefund = true;
+//             %obj.killBrick();
+//         }
+//     }
+// }
+
+function Plants_FindWall(%obj)
 {
-    //Vines will attempt to grow along walls
-    //Moss will attempt to grow along floors and ceilings. Will not stack vertically.
-    //Cacti will grow only grow upwards, up to a stack limit. Will not grow if horizontally adjacent to another cacti block
-    //All types will only grow on blocks owned by the same bl_id
-    //bl_id 888888 and 1337 are blacklisted completely
+    %plantPosition = %obj.getPosition();
+    %plantGroup = %obj.getGroup();
+    //find wall
+    %c = -1;
+    %vec[%c++] = vectorAdd(%plantPosition,"0.5 0 0");
+    %vec[%c++] = vectorAdd(%plantPosition,"0 0.5 0");
+    %vec[%c++] = vectorAdd(%plantPosition,"-0.5 0 0");
+    %vec[%c++] = vectorAdd(%plantPosition,"0 -0.5 0");
+    for(%i = 0; %i < 4; %i++)
+    {
+        %hit = containerRaycast(%plantPosition,%vec[%i],$TypeMasks::FxBrickAlwaysObjectType,%obj);
+        if(%hit != 0 && !%hit.getDatablock().isPlantBrick && %hit.getGroup() == %plantGroup)
+        {
+            %walls = %walls TAB %hit;
+        }
+    }
 
-    if (!isObject(%client = %obj.getGroup().client))
+    %walls = lTrim(%walls);
+
+    if(%walls $= "")
+    {
+        return "";
+    }
+
+    //to prevent from prefering a certain wall
+    return getField(%walls,getRandom(0,getFieldCount(%walls) - 1));
+}
+
+function Plants_FindFloor(%obj)
+{
+    %plantPosition = %obj.getPosition();
+    %plantGroup = %obj.getGroup();
+    //find floor
+    %hit = containerRaycast(%plantPosition,vectorAdd(%plantPosition,"0 0 -0.15"),$TypeMasks::FxBrickAlwaysObjectType,%obj);
+    if(%hit != 0 && !%hit.getDatablock().isPlantBrick && %hit.getGroup() == %plantGroup)
+    {
+        return %hit;
+    }
+
+    return "";
+}
+
+function Plants_Grow(%obj,%floating,%surfaceNormal,%possiblePositions,%color,%alwaysAge,%ageColor)
+{
+    if(%possiblePositions $= "")
+    {
+        //this part of the plant is finished growing
+        %obj.getGroup().EOTWPlants.remove(%obj);
+        return "";
+    }
+
+    %positionsNormal = getRecord(%possiblePositions,2);
+    %target = vectorAdd(matrixMultiply("0 0 0" SPC vectorNormalize(vectorCross(%surfaceNormal,%positionsNormal)) SPC mAcos(VectorDot(%surfaceNormal,%positionsNormal)),getField(%possiblePositions,getRandom(0,getRecord(%possiblePositions,1) - 1))),%obj.getPosition());
+
+    if(%alwaysAge)
+    {
+        %obj.setcolor(%ageColor);
+    }
+
+    %output = CreateBrick(%obj.getGroup().client, %obj.getDatablock(),  %target, %color, 0, true);
+    %brick = getField(%output, 0);
+    %err = getField(%output, 1);
+    if (!isObject(%brick))
+    {
         return;
-
-    %data = %obj.getDatablock();
-
-    if (%data.getName() $= "brickEOTWVinesData")
-    {
-        if (isObject(%obj.getDownBrick(0)) && !%obj.isplanted)
-            return;
-
-        if(%obj.length > 16)
-            return;
-
-        %output = CreateBrick(%client, %data, vectorAdd(%obj.getPosition(), "0 0 -0.2"), %obj.getColorID(), %angleID, true);
-        %brick = getField(%output, 0);
-        %err = getField(%output, 1);
-        if (isObject(%brick))
-        {
-            if (%err > 0)
-            {
-                %brick.dontRefund = true;
-                %brick.delete();
-            }
-            else
-            {
-                %brick.Material = "Custom";
-                %brick.length = %obj.length + 1;
-            }
-        }
     }
-    else if (%data.getName() $= "brickEOTWMossData")
+
+    if (%err > 0 && (!%floating && %err == 2))
     {
-        %angleID = getRandom(0, 3);
-
-        switch (%angleID)
-        {
-             case 0: %dir = "0.5 0 0";
-             case 1: %dir = "-0.5 0 0";
-             case 2: %dir = "0 0.5 0";
-             case 3: %dir = "0 -0.5 0";
-        }
-
-        %output = CreateBrick(%client, %data, vectorAdd(%obj.getPosition(), %dir), %obj.getColorID(), %angleID, true);
-        %brick = getField(%output, 0);
-        %err = getField(%output, 1);
-        if (isObject(%brick))
-        {
-            for (%i = 0; isObject(%colBrick = %brick.getDownBrick(%i)); %i++)
-            {
-                if (%colBrick.getGroup() == %brick.getGroup())
-                {
-                    %winCount++;
-                    break;
-                }
-            }
-            for (%i = 0; isObject(%colBrick = %brick.getUpBrick(%i)); %i++)
-            {
-                if (%colBrick.getGroup() == %brick.getGroup())
-                {
-                    %winCount++;
-                    break;
-                }
-            }
-            %brick.Material = "Custom";
-
-            if (%winCount < 1 || %err > 0)
-            {
-                %brick.dontRefund = true;
-                %brick.delete();
-            }
-        }
-        
+        %brick.dontRefund = true;
+        %brick.delete();
+        return;
     }
-    else if (%data.getName() $= "brickEOTWCactiData")
+
+    if(!%alwaysAge)
     {
-        if (isObject(%obj.getUpBrick(0)) && !%obj.isplanted)
-            return;
-
-        if(%obj.length > 16)
-            return;
-
-        %output = CreateBrick(%client, %data, vectorAdd(%obj.getPosition(), "0 0 0.2"), %obj.getColorID(), %angleID, true);
-        %brick = getField(%output, 0);
-        %err = getField(%output, 1);
-        if (isObject(%brick))
-        {
-            if (%err > 0)
-            {
-                %brick.dontRefund = true;
-                %brick.delete();
-            }
-            else
-            {
-                %brick.Material = "Custom";
-                %brick.length = %obj.length + 1;
-            }
-        }
-        
+        %obj.setcolor(%ageColor);
     }
-    else if (%data.getName() $= "brickEOTWDeadPlantData")
-    {
-        %obj.energy--;
-        if (%obj.energy < -10)
-        {
-            %obj.dontRefund = true;
-            %obj.killBrick();
-        }
-    }
+
+    %brick.Material = "Custom";
+
+    return %brick;
+}
+
+function Plants_Kill(%obj)
+{
+    %obj.getGroup().EOTWPlants.remove(%obj);
 }
 
 datablock fxDTSBrickData (brickEOTWVinesData)
@@ -152,7 +182,71 @@ datablock fxDTSBrickData (brickEOTWVinesData)
 
     isPlantBrick = true;
 };
-$EOTW::CustomBrickCost["brickEOTWVinesData"] = (1/8) TAB "264b38ff" TAB 128 TAB "Vines";
+$EOTW::CustomBrickCost["brickEOTWVinesData"] = (1/8) TAB "007c3fff" TAB 128 TAB "Vines";
+
+//vines grow along walls and form pretty patterns :)
+//against a wall
+$Vines::PositionsLookup[false] = "0 0 0.2" TAB "-0.5 0 0.2" TAB "-0.5 0 0" TAB "-0.5 0 -0.2" TAB "0 0 -0.2" TAB "0.5 0 -0.2" TAB "0.5 0 0" TAB "0.5 0 0.2" 
+    NL 8
+    NL "0 1 0";
+//against a wall and on a floor
+$Vines::PositionsLookup[true] = "0.5 0 0.2" TAB "0 0 0.2" TAB "-0.5 0 0.2"
+    NL 3
+    NL "0 1 0"; 
+//against a wall
+$VinesLeaves::PositionsLookup[false] = "0 0.5 0.2" TAB "-0.5 0.5 0.2" TAB "-0.5 0.5 0" TAB "-0.5 0.5 -0.2" TAB "0 0.5 -0.2" TAB "0.5 0.5 -0.2" TAB "0.5 0.5 0" TAB "0.5 0.5 0.2" TAB "0 0.5 0" 
+    NL 9
+    NL "0 1 0";
+//against a wall and on a floor
+$VinesLeaves::PositionsLookup[true] = "0.5 0.5 0.2" TAB "0 0.5 0.2" TAB "-0.5 0.5 0.2"
+    NL 3
+    NL "0 1 0";
+function brickEOTWVinesData::Grow(%data,%obj)
+{
+    if(%obj.colorid == 33)
+    {
+        Plants_Kill(%obj);
+        return "";
+    }  
+    %wall = Plants_FindWall(%obj);
+    %surfaceNormal = getWords(%wall,4,6);
+
+    //no wall
+    if(%wall $= "")
+    {
+        Plants_Kill(%obj);
+        return "";
+    }
+
+    //find floor
+    %hasFloor = Plants_FindFloor(%obj) !$= "";
+
+    %alwaysAge = true;
+    //is a new vine will always age and attempt to grow
+    if(%obj.colorid == 6)
+    {
+        %ageColor = 15;
+        %possiblePositions = $Vines::PositionsLookup[%hasFloor];
+    }
+
+    //is an older vine and has a chance for leaves or splitting
+    else if(%obj.colorid == 15)
+    {   
+        %ageColor = 33;
+        //older vines have a chance to split
+        if(getRandom() < 0.75)
+        {
+            %alwaysAge = false;
+            %possiblePositions = $Vines::PositionsLookup[%hasFloor];
+        }
+        else
+        {
+            %possiblePositions = $VinesLeaves::PositionsLookup[%hasFloor];
+        }
+    }  
+
+    Plants_Grow(%obj,true,%surfaceNormal,%possiblePositions,6,%alwaysAge,%ageColor);
+}
 
 datablock fxDTSBrickData (brickEOTWMossData)
 {
@@ -164,7 +258,62 @@ datablock fxDTSBrickData (brickEOTWMossData)
 
     isPlantBrick = true;
 };
-$EOTW::CustomBrickCost["brickEOTWMossData"] = (1/8) TAB "446942ff" TAB 128 TAB "Moss";
+$EOTW::CustomBrickCost["brickEOTWMossData"] = (1/8) TAB "899549ff" TAB 128 TAB "Moss";
+
+//moss can grow around like moss does but can also grow up a plate
+//not against a wall
+$Moss::PositionsLookup[false] = "0.5 0 0" TAB "0.5 0.5 0" TAB "0 0.5 0" TAB "-0.5 0.5 0" TAB "-0.5 0 0" TAB "-0.5 -0.5 0" TAB "0 -0.5 0" TAB "0.5 -0.5 0" 
+    NL 8
+    NL "0 0 1";
+
+//against a wall
+$Moss::PositionsLookup[true] = "0 -0.5 0.2"
+    NL 1
+    NL "0 1 0";
+
+function brickEOTWMossData::Grow(%data,%obj)
+{
+    if(%obj.colorid == 31)
+    {
+        Plants_Kill(%obj);
+        return "";
+    }
+
+    //find floor
+    %floor = Plants_FindFloor(%obj);
+    %surfaceNormal = getWords(%floor,4,6);
+
+    if(%floor $= "")
+    {
+        Plants_Kill(%obj);
+        return "";
+    }
+
+    %possiblePositions = $Moss::PositionsLookup[false];
+
+    %wall = Plants_FindWall(%obj);
+    if(%wall !$= "" && getRandom() < 0.5)
+    {
+        %surfaceNormal = getWords(%wall,4,6);
+        %possiblePositions = $Moss::PositionsLookup[true];
+    }
+
+    %alwaysAge = true;
+    if(%obj.colorid == 4)
+    {
+        %agecolor = 13;
+    }
+    else if(%obj.colorid >= 13)
+    {
+        %agecolor = 31;
+        if(getRandom() < 0.5)
+        {
+            %alwaysAge = false;
+        }
+    }
+
+    Plants_Grow(%obj,false,%surfaceNormal,%possiblePositions,4,%alwaysAge,%agecolor);
+}
 
 datablock fxDTSBrickData (brickEOTWCactiData)
 {
@@ -176,7 +325,64 @@ datablock fxDTSBrickData (brickEOTWCactiData)
 
     isPlantBrick = true;
 };
-$EOTW::CustomBrickCost["brickEOTWCactiData"] = (1/8) TAB "56643bff" TAB 128 TAB "Cacti";
+$EOTW::CustomBrickCost["brickEOTWCactiData"] = (1/8) TAB "5d803fff" TAB 128 TAB "Cacti";
+
+$Cactus::PositionsLookup[false] = "0 0 0.2"
+    NL 1
+    NL "0 0 1";
+$Cactus::PositionsLookup[true] = "0.5 0 0" TAB "0 0.5 0" TAB "-0.5 0 0" TAB "0 -0.5 0"
+    NL 4
+    NL "0 0 1";
+
+function brickEOTWCactiData::Grow(%data,%obj)
+{
+    if(%obj.colorid == 32)
+    {
+        Plants_Kill(%obj);
+        return "";
+    }
+
+    %floating = false;
+    %alwaysAge = true;
+    if(%obj.colorid == 5)
+    {
+        %possiblePositions = $Cactus::PositionsLookup[false];
+        %agecolor = 32;
+        %color = 5;
+        if(getRandom() < 0.0666)
+        {
+            Plants_Grow(%obj,true,"0 0 1",$Cactus::PositionsLookup[true],13,false,4);
+            %color = 4;
+        }
+    }
+    else if (%obj.colorid == 4)
+    {
+        %possiblePositions = $Cactus::PositionsLookup[false];
+        %agecolor = 32;
+        %color = 4;
+
+        if(getRandom() < 0.025)
+        {
+            Plants_Grow(%obj,true,"0 0 1",$Cactus::PositionsLookup[true],13,false,4);
+            %color = 4;
+        }
+        else if(getRandom() < 0.1)
+        {
+            %color = 32;
+        }
+
+    }
+    else if(%obj.colorid == 13)
+    {
+        %agecolor = 32;
+        %color = 4;
+        %possiblePositions = $Cactus::PositionsLookup[true];
+        %alwaysAge = false;
+        %floating = true;
+    }
+
+    Plants_Grow(%obj,%floating,"0 0 1",%possiblePositions,%color,%alwaysAge,%agecolor);
+}
 
 datablock fxDTSBrickData (brickEOTWDeadPlantData)
 {
@@ -190,20 +396,26 @@ datablock fxDTSBrickData (brickEOTWDeadPlantData)
 };
 $EOTW::CustomBrickCost["brickEOTWDeadPlantData"] = (1/16) TAB "75502eff" TAB 16 TAB "Wood";
 
+function brickEOTWDeadPlantData::Grow(%data,%obj)
+{
+    return;
+}
+
 package EOTW_Plants
 {
     function fxDtsBrick::onPlant(%obj,%b)
 	{
+        %brick.isFloatingBrick = true;
 		parent::onPlant(%obj,%b);
 
         if (%obj.getDatablock().isPlantBrick)
         {
-            if (!isObject(EOTWPlants))
+            %group = %obj.getGroup();
+            if (!isObject(%group.EOTWPlants))
             {
-                new SimSet(EOTWPlants);
-                PlantLife_TickLoop();
+                %group.EOTWPlants = new SimSet();
             }
-            EOTWPlants.add(%obj);
+            %group.EOTWPlants.add(%obj);
         }
 	}
 
@@ -213,13 +425,22 @@ package EOTW_Plants
 
         if (%obj.getDatablock().isPlantBrick)
         {
-            if (!isObject(EOTWPlants))
+            if (!isObject(%group.EOTWPlants))
             {
-                new SimSet(EOTWPlants);
-                PlantLife_TickLoop();
+                %group.EOTWPlants = new SimSet();
             }
-            EOTWPlants.add(%obj);
+            %group.EOTWPlants.add(%obj);
         }
 	}
+
+    function paintProjectile::onCollision(%this, %obj, %col, %fade, %pos, %normal)
+    {
+        if(%col.getDatablock().isPlantBrick)
+        {
+            return;
+        }
+        return Parent::onCollision(%this, %obj, %col, %fade, %pos, %normal);
+    }
+
 };
 activatePackage("EOTW_Plants");


### PR DESCRIPTION
Reworks all plants to look and act a little nicer. This adds some default functionality between all plants and also unspaghetifies the file. Plants will "die" semi randomly when they aren't able to randomly grow. This should greatly decrease the chances of having thousands of plant bricks trying to tick every plant update. There is also a cap on the max number of plant ticks per update to enforce not having lag over plant ticks.

Vines will grow along a wall but cannot grow around corners. Vines will also grow leaves.

Moss will grow along the ground and can grow on top of itself. It is capable of growing up single tile stairs but not down.

Cacti will grow straight up and has a chance to split at least once before finishing growing.

All floating bricks are handled correctly so no worry about not being able to hammer them if you don't have a sickle.